### PR TITLE
[chore] 개발서버 url 변경

### DIFF
--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -5,12 +5,14 @@ export const appVersion = '1.0';
 const description = `
 The Cloud-GUI API description  
 화이팀 API 서버 명세서입니다.  
-개발 BaseUrl : http://52.79.126.134:3000/  
+개발 BaseUrl : http://causeapiserver-env.eba-pegczwgz.ap-northeast-2.elasticbeanstalk.com/api-docs/  
 `;
 
 export const swaggerConfig = new DocumentBuilder()
   .addServer('http://localhost:3000')
-  .addServer('http://52.79.126.134:3000/')
+  .addServer(
+    'http://causeapiserver-env.eba-pegczwgz.ap-northeast-2.elasticbeanstalk.com/',
+  )
   .setTitle('Cloud-GUI')
   .setDescription(description)
   .setVersion(appVersion)


### PR DESCRIPTION
## 📌 개발 이유
배포 자동화로 인해 개발 서버 URL 이 변경되었습니다. 

## 💻 수정 사항
기존 개발 서버 URL http://52.79.126.134 에서 
http://causeapiserver-env.eba-pegczwgz.ap-northeast-2.elasticbeanstalk.com/
으로 변경되었습니다. 

@joohaem @yujisoo @EXAMPLE1ST 