### PR TITLE
[docs] 결과페이지 기능 구현을 위한 API 명세서 작성 

### DIFF
--- a/src/instances/docs/swagger.ts
+++ b/src/instances/docs/swagger.ts
@@ -6,6 +6,7 @@ import {
   ApiParam,
 } from '@nestjs/swagger';
 import { CreateInstanceDto, InstanceResponseDto } from 'src/instances/dto';
+import { InstanceConnectionConfigResponseDto } from 'src/instances/dto/instance-connection-config-response.dto';
 import { JwtHeader } from 'src/utils/swagger';
 
 export function GetInstancesDocs() {
@@ -70,6 +71,19 @@ export function DeleteInstanceDocs() {
     }),
     ApiOkResponse({
       type: Boolean,
+    }),
+  );
+}
+
+export function GetInstancesBackendDocs() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '백엔드 인스턴스 정보 가져오기',
+      deprecated: true,
+    }),
+    JwtHeader,
+    ApiOkResponse({
+      type: InstanceConnectionConfigResponseDto,
     }),
   );
 }

--- a/src/instances/dto/instance-connection-config-response.dto.ts
+++ b/src/instances/dto/instance-connection-config-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InstanceConnectionConfigResponseDto {
+  @ApiProperty({
+    description: '인스턴스 아이피',
+    required: true,
+    type: String,
+    nullable: true,
+  })
+  publicIp: string | null;
+}

--- a/src/instances/instances.controller.ts
+++ b/src/instances/instances.controller.ts
@@ -13,6 +13,7 @@ import {
   CreateInstanceDocs,
   DeleteInstanceDocs,
   GetInstanceDocs,
+  GetInstancesBackendDocs,
   GetInstancesDocs,
 } from 'src/instances/docs/swagger';
 import { CreateInstanceDto } from 'src/instances/dto';
@@ -51,5 +52,11 @@ export class InstancesController {
   @DeleteInstanceDocs()
   async delete() {
     return 'DELETE /instances/:instanceId';
+  }
+
+  @Get('backend')
+  @GetInstancesBackendDocs()
+  async getBackendInstance() {
+    return 'GET /instances/backend';
   }
 }

--- a/src/rds/docs/swagger.ts
+++ b/src/rds/docs/swagger.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/swagger';
 
 import { CreateRdsDto, RdsResponseDto } from 'src/rds/dto';
+import { RdsConnectionConfigResponseDto } from 'src/rds/dto/rds-connection-config-response.dto';
 import { JwtHeader } from 'src/utils/swagger';
 
 export function GetRdsesDocs() {
@@ -72,6 +73,19 @@ export function DeleteRdsDocs() {
     }),
     ApiOkResponse({
       type: Boolean,
+    }),
+  );
+}
+
+export function GetRdsConfig() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'RDS 접속 정보 가져오기',
+      deprecated: true,
+    }),
+    JwtHeader,
+    ApiOkResponse({
+      type: RdsConnectionConfigResponseDto,
     }),
   );
 }

--- a/src/rds/dto/rds-connection-config-response.dto.ts
+++ b/src/rds/dto/rds-connection-config-response.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RdsConnectionConfigResponseDto {
+  @ApiProperty({
+    description: 'RDS host',
+    required: true,
+    type: String,
+    nullable: true,
+  })
+  host: string | null;
+
+  @ApiProperty({
+    description: 'RDS user',
+    required: true,
+    type: String,
+    nullable: true,
+  })
+  user: string | null;
+
+  @ApiProperty({
+    description: 'RDS password',
+    required: true,
+    type: String,
+    nullable: true,
+  })
+  password: string | null;
+}

--- a/src/rds/rds.controller.ts
+++ b/src/rds/rds.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags } from '@nestjs/swagger';
 import {
   CreateRdsDocs,
   DeleteRdsDocs,
+  GetRdsConfig,
   GetRdsDocs,
   GetRdsesDocs,
 } from 'src/rds/docs/swagger';
@@ -32,5 +33,11 @@ export class RdsController {
   @DeleteRdsDocs()
   async deleteRds() {
     return 'DELETE /rdses/:rdsId';
+  }
+
+  @Get('config')
+  @GetRdsConfig()
+  async getRdsConfig() {
+    return 'GET /rds/config';
   }
 }


### PR DESCRIPTION
## 📌 개발 이유
지수와 예원이의 결과페이지 기능 구현을 위한 필요한 정보를 가져갈 수 있는 API 명세서를 작성했습니다. 

## 💻 수정 사항
- GET /instances/backend API 추가 
![스크린샷 2022-11-13 오후 11 13 05](https://user-images.githubusercontent.com/44994031/201526285-b16e9391-c2dc-4df8-9566-a087406e6ee3.png)
해당 API를 호출해 backend 인스턴스의 IP 를 가져올 수 있습니다. 
ip가 없는 경우 null을 반환합니다.

- GET /rds/config API 추가 
![스크린샷 2022-11-13 오후 11 13 29](https://user-images.githubusercontent.com/44994031/201526309-10af9d2e-2207-4818-8fd8-1f9ca0fdcc7f.png)
해당 API를 호출해 rds의 접속에 필요한 정보를 가져올 수 있습니다.
정보가 없는 경우 null을 반환합니다. 

## 🧪 테스트 방법
API 명세서는 다음 주소에서 볼 수 있습니다. 
http://causeapiserver-env.eba-pegczwgz.ap-northeast-2.elasticbeanstalk.com/api-docs

## ✅ 궁금한 점 & 리뷰 포인트
@yujisoo @EXAMPLE1ST 
