### PR TITLE
[feat] DELETE /instances/:instanceId API 개발

### DIFF
--- a/src/instances/docs/swagger.ts
+++ b/src/instances/docs/swagger.ts
@@ -61,7 +61,6 @@ export function DeleteInstanceDocs() {
   return applyDecorators(
     ApiOperation({
       summary: '인스턴스 삭제하기',
-      deprecated: true,
     }),
     JwtHeader,
     ApiParam({

--- a/src/instances/instances.controller.ts
+++ b/src/instances/instances.controller.ts
@@ -115,8 +115,12 @@ export class InstancesController {
 
   @Delete(':instanceId')
   @DeleteInstanceDocs()
-  async delete() {
-    return 'DELETE /instances/:instanceId';
+  async delete(
+    @Request() req: AuthorizedRequest,
+    @Param('instanceId') instanceId: string,
+  ) {
+    const userId = getUserId(req);
+    return await this.instancesService.delete(userId, instanceId);
   }
 
   @Get('backend')


### PR DESCRIPTION
## 📌 개발 이유
인스턴스 삭제 API를 개발했습니다. 

## 💻 수정 사항
InstanceController.delete() 개발 
InstanceService.delete() 개발 

이전 커밋이 이전 PR에 겹쳐서 올라갔네요. 
수정사항 추가합니다. 
InstanceResponseDto에서 storage 관련 정보가 삭제되었습니다. 
![스크린샷 2022-11-28 오전 1 20 57](https://user-images.githubusercontent.com/44994031/204145994-2fb1affe-0970-4683-9595-07fa7dc137d9.png)

## 🧪 테스트 방법
swagger 상으로 테스트를 해봅시다. 
DELETE /instances/:instanceId API를 호출합시다. 
instanceId에 현재 존재하는 instanceId를 넣어줘야합니다. 
그리고,,,, AWS 상에서 해당 인스턴스가 종료중,,,, 으로 변경되었는지 확인합니다. 

InstanceResponseDto 에서 storage 관련 정보가 삭제되었는지 확인합니다. 

## ✅ 궁금한 점 & 리뷰 포인트
@joohaem 