### PR TITLE
[feat] GET /instances/backend API 개발, 백엔드 개발 서버 주소 변경 

### DIFF
--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -10,9 +10,7 @@ The Cloud-GUI API description
 
 export const swaggerConfig = new DocumentBuilder()
   .addServer('http://localhost:3000')
-  .addServer(
-    'http://causeapiserver-env.eba-pegczwgz.ap-northeast-2.elasticbeanstalk.com/',
-  )
+  .addServer(`https://dev.cloud-gui.com`)
   .setTitle('Cloud-GUI')
   .setDescription(description)
   .setVersion(appVersion)

--- a/src/constants/instance.ts
+++ b/src/constants/instance.ts
@@ -1,24 +1,19 @@
-export const UBUNTU20_IMAGE_ID = 'ami-07d16c043aa8e5153';
+export const CENTOS_IMAGE_ID = 'ami-03bb74d9c8c575ec0';
+export const UBUNTU20_IMAGE_ID = 'ami-0a74c05e1e3b13202';
 export const FRONTEND_DOCKER_IMAGE_NAME = `deokam/react-nginx:1.1`;
-export const FRONTEND_USER_DATA_SCRIPT = `#!/bin/bash
-sudo apt-get update && upgrade
 
-sudo -y apt-get install \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
-
-sudo mkdir -p /etc/apt/rings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/rings/docker.gpg 
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/rings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-sudo apt update
-sudo apt -y install docker-ce docker-ce-cli containerd.io
-sudo systemctl enable docker.service
-
+export const BACKEND_UBUNTU_USER_DATA_SCRIPT = `#!/bin/bash
 sudo docker pull deokam/result-page:1.0
-sudo docker run -d -p 80:80 --name react-test deokam/result-page:1.0
- `;
+sudo docker run -d -p 80:80 --name react-test deokam/result-page:1.0`;
+
+export const BACKEND_CENTOS_USER_DATA_SCRIPT = `#!/bin/bash
+ sudo docker pull deokam/result-page:1.0
+ sudo docker run -d -p 80:80 --name react-test deokam/result-page:1.0`;
+
+export const FRONTEND_UBUNTU_USER_DATA_SCRIPT = `#!/bin/bash
+sudo docker pull deokam/result-page:1.0
+sudo docker run -d -p 80:80 --name react-test deokam/result-page:1.0`;
+
+export const FRONTEND_CENTOS_USER_DATA_SCRIPT = `#!/bin/bash
+ sudo docker pull deokam/result-page:1.0
+ sudo docker run -d -p 80:80 --name react-test deokam/result-page:1.0`;

--- a/src/instances/docs/swagger.ts
+++ b/src/instances/docs/swagger.ts
@@ -78,7 +78,6 @@ export function GetInstancesBackendDocs() {
   return applyDecorators(
     ApiOperation({
       summary: '백엔드 인스턴스 정보 가져오기',
-      deprecated: true,
     }),
     JwtHeader,
     ApiOkResponse({

--- a/src/instances/instances.controller.ts
+++ b/src/instances/instances.controller.ts
@@ -118,7 +118,7 @@ export class InstancesController {
   async delete(
     @Request() req: AuthorizedRequest,
     @Param('instanceId') instanceId: string,
-  ) {
+  ): Promise<boolean> {
     const userId = getUserId(req);
     return await this.instancesService.delete(userId, instanceId);
   }

--- a/src/instances/instances.controller.ts
+++ b/src/instances/instances.controller.ts
@@ -21,6 +21,7 @@ import {
   GetInstancesDocs,
 } from 'src/instances/docs/swagger';
 import { CreateInstanceDto } from 'src/instances/dto';
+import { InstanceConnectionConfigResponseDto } from 'src/instances/dto/instance-connection-config-response.dto';
 import { InstanceResponseDto } from 'src/instances/dto/instance-response.dto';
 import { InstancesService } from 'src/instances/instances.service';
 import { getInstanceResponseDtoFromInstances } from 'src/instances/utils/getInstances';
@@ -33,6 +34,7 @@ import { AuthorizedRequest } from 'src/utils/types';
 @Controller('instances')
 export class InstancesController {
   constructor(private readonly instancesService: InstancesService) {}
+
   @Get()
   @GetInstancesDocs()
   async getInstances(@Request() req: AuthorizedRequest) {
@@ -49,6 +51,29 @@ export class InstancesController {
       savedInstances,
       fetchedInstances,
     );
+  }
+
+  @Get('backend')
+  @GetInstancesBackendDocs()
+  async getBackendInstance(
+    @Request() req: AuthorizedRequest,
+  ): Promise<InstanceConnectionConfigResponseDto> {
+    const userId = getUserId(req);
+    const res = await this.instancesService.getInstances(userId, {
+      backend: true,
+    });
+
+    if (!res || res.fetchedInstances.length == 0) {
+      return { publicIp: null };
+    }
+
+    const { savedInstances, fetchedInstances } = res;
+    const instanceResponseDtos = await getInstanceResponseDtoFromInstances(
+      savedInstances,
+      fetchedInstances,
+    );
+
+    return { publicIp: instanceResponseDtos[0].informations.publicIp };
   }
 
   @Get(':instanceId')
@@ -121,11 +146,5 @@ export class InstancesController {
   ): Promise<boolean> {
     const userId = getUserId(req);
     return await this.instancesService.delete(userId, instanceId);
-  }
-
-  @Get('backend')
-  @GetInstancesBackendDocs()
-  async getBackendInstance() {
-    return 'GET /instances/backend';
   }
 }

--- a/src/instances/instances.service.ts
+++ b/src/instances/instances.service.ts
@@ -5,10 +5,6 @@ import {
 } from '@nestjs/common';
 import { CreateInstanceDto } from 'src/instances/dto';
 import * as AWS from 'aws-sdk';
-import {
-  FRONTEND_USER_DATA_SCRIPT,
-  UBUNTU20_IMAGE_ID,
-} from 'src/constants/instance';
 import { updateAWSCredential } from 'src/aws/common';
 import { createSecurityGroup } from 'src/aws/ec2';
 import { ReturnedUser, UsersService } from 'src/users/users.service';
@@ -20,6 +16,7 @@ import {
 import { Model, Schema } from 'mongoose';
 import { PromiseResult } from 'aws-sdk/lib/request';
 import { InstanceTier } from 'src/instances/dto/instance-response.dto';
+import { getCreateInstanceInfo } from 'src/instances/utils/getCaseInfo';
 export type InstanceModel = Instance &
   Document &
   Required<{
@@ -154,13 +151,15 @@ export class InstancesService {
       [];
 
     for (const createInstanceDto of createInstanceDtos) {
+      const info = getCreateInstanceInfo(createInstanceDto);
+
       const instanceParams: AWS.EC2.RunInstancesRequest = {
-        ImageId: UBUNTU20_IMAGE_ID,
+        ImageId: info.imageId,
         InstanceType: 't2.micro',
         KeyName: 'cause-api-server-dev',
         MinCount: 1,
         MaxCount: 1,
-        UserData: Buffer.from(FRONTEND_USER_DATA_SCRIPT).toString('base64'),
+        UserData: Buffer.from(info.userData).toString('base64'),
         SecurityGroupIds: [securityGroupId],
       };
 

--- a/src/instances/utils/getCaseInfo.ts
+++ b/src/instances/utils/getCaseInfo.ts
@@ -1,0 +1,58 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import {
+  BACKEND_CENTOS_USER_DATA_SCRIPT,
+  BACKEND_UBUNTU_USER_DATA_SCRIPT,
+  CENTOS_IMAGE_ID,
+  FRONTEND_CENTOS_USER_DATA_SCRIPT,
+  FRONTEND_UBUNTU_USER_DATA_SCRIPT,
+  UBUNTU20_IMAGE_ID,
+} from 'src/constants/instance';
+import { CreateInstanceDto } from 'src/instances/dto';
+import {
+  InstanceOS,
+  InstanceTier,
+} from 'src/instances/dto/instance-response.dto';
+
+export class CreateInstanceInfo {
+  imageId: string;
+  userData: string;
+}
+
+export function getCreateInstanceInfo(
+  createInstanceDto: CreateInstanceDto,
+): CreateInstanceInfo {
+  if (
+    createInstanceDto.os == InstanceOS.CENTOS &&
+    createInstanceDto.tier == InstanceTier.WEBSERVER
+  ) {
+    return {
+      imageId: CENTOS_IMAGE_ID,
+      userData: FRONTEND_CENTOS_USER_DATA_SCRIPT,
+    };
+  } else if (
+    createInstanceDto.os == InstanceOS.CENTOS &&
+    createInstanceDto.tier == InstanceTier.WAS
+  ) {
+    return {
+      imageId: CENTOS_IMAGE_ID,
+      userData: BACKEND_CENTOS_USER_DATA_SCRIPT,
+    };
+  } else if (
+    createInstanceDto.os == InstanceOS.UBUNTU &&
+    createInstanceDto.tier == InstanceTier.WEBSERVER
+  ) {
+    return {
+      imageId: UBUNTU20_IMAGE_ID,
+      userData: FRONTEND_UBUNTU_USER_DATA_SCRIPT,
+    };
+  } else if (
+    createInstanceDto.os == InstanceOS.UBUNTU &&
+    createInstanceDto.tier == InstanceTier.WAS
+  ) {
+    return {
+      imageId: UBUNTU20_IMAGE_ID,
+      userData: BACKEND_UBUNTU_USER_DATA_SCRIPT,
+    };
+  }
+  throw new InternalServerErrorException('기대되지 않는 값입니다.');
+}

--- a/src/instances/utils/getInstanceOptions.ts
+++ b/src/instances/utils/getInstanceOptions.ts
@@ -1,0 +1,9 @@
+export class getInstanceOptions {
+  backend?: boolean;
+  frontend?: boolean;
+}
+
+export const defaultGetInstanceOptions: getInstanceOptions = {
+  backend: true,
+  frontend: true,
+};


### PR DESCRIPTION
## 📌 개발 이유
예원이가 사용할 백엔드의 주소를 가져오는 API를 개발했습니다. 
백엔드 개발 서버 주소가 변경되었습니다. 


## 💻 수정 사항
GET /instances/backend API 개발 완료. 

백엔드 API 주소 변경 
기존 : http://causeapiserver-env.eba-pegczwgz.ap-northeast-2.elasticbeanstalk.com/api-docs
변경 : https://dev.cloud-gui.com

## 🧪 테스트 방법
swagger 상으로 접속해서 GET /instances/backend API를 호출해봅시다. 

## ✅ 궁금한 점 & 리뷰 포인트
@joohaem @EXAMPLE1ST 