### PR TITLE
[fix] instance id와 이름이 매칭안되는 버그 수정

### DIFF
--- a/src/aws/ec2.ts
+++ b/src/aws/ec2.ts
@@ -49,8 +49,6 @@ export const createSecurityGroup = async (
     ],
   };
 
-  const data = await ec2.authorizeSecurityGroupIngress(paramsIngress).promise();
-  console.log('Ingress Successfully Set', data);
-
+  await ec2.authorizeSecurityGroupIngress(paramsIngress).promise();
   return securityGroupId;
 };

--- a/src/instances/utils/getInstances.ts
+++ b/src/instances/utils/getInstances.ts
@@ -32,11 +32,18 @@ export const getInstanceResponseDtoFromInstances = (
 
   for (let i = 0; i < savedInstances.length; i++) {
     const savedInstance = savedInstances[i];
-    const fetchedInstance = fetchedInstances[i][0];
+    const instanceId = savedInstances[i].instanceId;
+    const fetchedInstance = fetchedInstances.find(
+      (instance) => instance[0].InstanceId == instanceId,
+    );
+
+    if (!fetchedInstance) {
+      throw new InternalServerErrorException('인스턴스를 찾을 수 없습니다.');
+    }
 
     const response: InstanceResponseDto = new InstanceResponseDto(
       savedInstance,
-      fetchedInstance,
+      fetchedInstance[0],
     );
     instanceResponseDtos.push(response);
   }


### PR DESCRIPTION
## 📌 개발 이유
버그 수정했습니다. 

### 관련 이슈가 있다면 적어주세요.
- #20 

## 💻 수정 사항
AWS 에서 가져온 instance 정보가 전달된 instanceId의 순서대로 온다는 순서가 보장되지 않습니다. 
fetchedInstance의 배열과 savedInstance의 배열에서 정보를 찾아 해당 정보로 InstanceResponseDto를 만들도록 수정했습니다. 

## 🧪 테스트 방법
swagger 상으로 GET /instances 를 통해 인스턴스 이름과 id가 정확하게 match 되는지 확인합니다. 

## ✅ 궁금한 점 & 리뷰 포인트
@joohaem 