### PR TITLE
[feat] github 주소 넣으면 자동으로 API 호출 

### DIFF
--- a/src/auth/pipes/user-login-validate.pipe.ts
+++ b/src/auth/pipes/user-login-validate.pipe.ts
@@ -3,7 +3,8 @@ import { LoginUserDto } from 'src/auth/dto';
 
 export class UserLoginDtoValidationPipe implements PipeTransform {
   transform(value: LoginUserDto): LoginUserDto {
-    // 추후 로직 작성
+    value.email = value.email.trim();
+    value.password = value.password.trim();
     return value;
   }
 }

--- a/src/constants/instance.ts
+++ b/src/constants/instance.ts
@@ -1,5 +1,7 @@
 export const CENTOS_IMAGE_ID = 'ami-03bb74d9c8c575ec0';
 export const UBUNTU20_IMAGE_ID = 'ami-0a74c05e1e3b13202';
+export const NODE_CENTOS_IMAGE_ID = 'ami-07f334dabe4604359';
+export const NODE_UBUNTU_IMAGE_ID = 'ami-055c5847c770c5345';
 export const FRONTEND_DOCKER_IMAGE_NAME = `deokam/result-page:latest`;
 export const BACKEND_DOCKER_IMAGE_NAME = `sdbwltns/capston:latest`;
 
@@ -14,3 +16,13 @@ sudo docker run -d -p 80:80 --name frontend ${FRONTEND_DOCKER_IMAGE_NAME}`;
 
 export const FRONTEND_CENTOS_USER_DATA_SCRIPT = `#!/bin/bash
 sudo docker run -d -p 80:80 --name frontend ${FRONTEND_DOCKER_IMAGE_NAME}`;
+
+export const getUserScript = (repository: string) => {
+  return `#!/bin/bash
+git clone ${repository} app
+cd app
+npm install
+npm run build
+npm run start
+`;
+};

--- a/src/instances/docs/swagger.ts
+++ b/src/instances/docs/swagger.ts
@@ -5,8 +5,11 @@ import {
   ApiOperation,
   ApiParam,
 } from '@nestjs/swagger';
-import { CreateInstanceDto, InstanceResponseDto } from 'src/instances/dto';
-import { InstanceConnectionConfigResponseDto } from 'src/instances/dto/instance-connection-config-response.dto';
+import {
+  CreateInstanceDto,
+  InstanceResponseDto,
+  InstanceConnectionConfigResponseDto,
+} from 'src/instances/dto';
 import { JwtHeader } from 'src/utils/swagger';
 
 export function GetInstancesDocs() {

--- a/src/instances/dto/create-instance.dto.ts
+++ b/src/instances/dto/create-instance.dto.ts
@@ -32,4 +32,11 @@ export class CreateInstanceDto {
     required: true,
   })
   name: string;
+
+  @ApiProperty({
+    description: '연동하고 싶은 github repository 주소',
+    required: true,
+    nullable: true,
+  })
+  githubUrl: string;
 }

--- a/src/instances/dto/index.ts
+++ b/src/instances/dto/index.ts
@@ -1,4 +1,9 @@
 import { CreateInstanceDto } from 'src/instances/dto/create-instance.dto';
 import { InstanceResponseDto } from 'src/instances/dto/instance-response.dto';
+import { InstanceConnectionConfigResponseDto } from 'src/instances/dto/instance-connection-config-response.dto';
 
-export { CreateInstanceDto, InstanceResponseDto };
+export {
+  CreateInstanceDto,
+  InstanceResponseDto,
+  InstanceConnectionConfigResponseDto,
+};

--- a/src/instances/dto/instance-response.dto.ts
+++ b/src/instances/dto/instance-response.dto.ts
@@ -24,6 +24,13 @@ export class InstanceOption {
     type: String,
   })
   name: string;
+
+  @ApiProperty({
+    description: '연동된 github Url',
+    required: true,
+    type: String,
+  })
+  githubUrl: string;
 }
 
 export class InstanceInformations {
@@ -100,6 +107,7 @@ export class InstanceResponseDto {
   ) {
     const instanceOption: InstanceOption = {
       name: savedInstance.name,
+      githubUrl: savedInstance.githubUrl,
     };
 
     if (!fetchedInstance.InstanceId) {

--- a/src/instances/dto/instance-response.dto.ts
+++ b/src/instances/dto/instance-response.dto.ts
@@ -107,7 +107,7 @@ export class InstanceResponseDto {
   ) {
     const instanceOption: InstanceOption = {
       name: savedInstance.name,
-      githubUrl: savedInstance.githubUrl,
+      githubUrl: savedInstance.githubUrl ? savedInstance.githubUrl : '',
     };
 
     if (!fetchedInstance.InstanceId) {

--- a/src/instances/instances.controller.ts
+++ b/src/instances/instances.controller.ts
@@ -20,9 +20,11 @@ import {
   GetInstancesBackendDocs,
   GetInstancesDocs,
 } from 'src/instances/docs/swagger';
-import { CreateInstanceDto } from 'src/instances/dto';
-import { InstanceConnectionConfigResponseDto } from 'src/instances/dto/instance-connection-config-response.dto';
-import { InstanceResponseDto } from 'src/instances/dto/instance-response.dto';
+import {
+  CreateInstanceDto,
+  InstanceConnectionConfigResponseDto,
+  InstanceResponseDto,
+} from 'src/instances/dto';
 import { InstancesService } from 'src/instances/instances.service';
 import { getInstanceResponseDtoFromInstances } from 'src/instances/utils/getInstances';
 import { getUserId } from 'src/users/utils';

--- a/src/instances/instances.service.ts
+++ b/src/instances/instances.service.ts
@@ -213,7 +213,11 @@ export class InstancesService {
 
       await ec2.createTags(tagParams).promise();
       instanceInfos.push(instanceInfo);
-      this.saveInstance(user, createInstanceDto, instanceInfo.Instances[0]);
+      await this.saveInstance(
+        user,
+        createInstanceDto,
+        instanceInfo.Instances[0],
+      );
     }
 
     return instanceInfos;
@@ -227,6 +231,7 @@ export class InstancesService {
     const createdInstance = await this.instanceModel.create({
       instanceId: instanceInfo.InstanceId,
       name: createInstanceDto.name,
+      githubUrl: createInstanceDto.githubUrl,
       publicIp: instanceInfo.PublicIpAddress || null,
       privateIp: instanceInfo.PrivateIpAddress,
       securityGroup: ['tcp : 80 - 0.0.0.0/0', 'tcp : 22 - 0.0.0.0/0'],
@@ -242,7 +247,7 @@ export class InstancesService {
       user.backendInstances.push(createdInstance._id);
     }
 
-    user.save();
+    await user.save();
   }
 
   async delete(userId: string, instanceId: string) {

--- a/src/instances/schemas/instance.schema.ts
+++ b/src/instances/schemas/instance.schema.ts
@@ -25,7 +25,6 @@ export class Instance {
   name: string;
 
   @Prop({
-    required: true,
     type: String,
     default: '',
   })

--- a/src/instances/schemas/instance.schema.ts
+++ b/src/instances/schemas/instance.schema.ts
@@ -25,6 +25,13 @@ export class Instance {
   name: string;
 
   @Prop({
+    required: true,
+    type: String,
+    default: '',
+  })
+  githubUrl: string;
+
+  @Prop({
     type: String,
   })
   publicIp: string | null;

--- a/src/instances/utils/getCaseInfo.ts
+++ b/src/instances/utils/getCaseInfo.ts
@@ -30,7 +30,7 @@ export function getCreateInstanceInfo(
   ) {
     return {
       imageId: NODE_CENTOS_IMAGE_ID,
-      userData: getUserScript(createInstanceDto.githubUrl),
+      userData: getUserScript(createInstanceDto.githubUrl.trim()),
     };
   } else if (
     createInstanceDto.githubUrl &&
@@ -38,7 +38,7 @@ export function getCreateInstanceInfo(
   ) {
     return {
       imageId: NODE_UBUNTU_IMAGE_ID,
-      userData: getUserScript(createInstanceDto.githubUrl),
+      userData: getUserScript(createInstanceDto.githubUrl.trim()),
     };
   } else if (
     createInstanceDto.os == InstanceOS.CENTOS &&

--- a/src/instances/utils/getCaseInfo.ts
+++ b/src/instances/utils/getCaseInfo.ts
@@ -5,6 +5,9 @@ import {
   CENTOS_IMAGE_ID,
   FRONTEND_CENTOS_USER_DATA_SCRIPT,
   FRONTEND_UBUNTU_USER_DATA_SCRIPT,
+  getUserScript,
+  NODE_CENTOS_IMAGE_ID,
+  NODE_UBUNTU_IMAGE_ID,
   UBUNTU20_IMAGE_ID,
 } from 'src/constants/instance';
 import { CreateInstanceDto } from 'src/instances/dto';
@@ -22,6 +25,22 @@ export function getCreateInstanceInfo(
   createInstanceDto: CreateInstanceDto,
 ): CreateInstanceInfo {
   if (
+    createInstanceDto.githubUrl &&
+    createInstanceDto.os == InstanceOS.CENTOS
+  ) {
+    return {
+      imageId: NODE_CENTOS_IMAGE_ID,
+      userData: getUserScript(createInstanceDto.githubUrl),
+    };
+  } else if (
+    createInstanceDto.githubUrl &&
+    createInstanceDto.os == InstanceOS.UBUNTU
+  ) {
+    return {
+      imageId: NODE_UBUNTU_IMAGE_ID,
+      userData: getUserScript(createInstanceDto.githubUrl),
+    };
+  } else if (
     createInstanceDto.os == InstanceOS.CENTOS &&
     createInstanceDto.tier == InstanceTier.WEBSERVER
   ) {


### PR DESCRIPTION
## 📌 개발 이유
github 코드를 가져와 서버를 실행해주는 기능을 추가했습니다. 

## 💻 수정 사항
CreateInstanceDto에 githubUrl 속성이 추가되었습니다. 
githubUrl을 추가하지 않으면 자동으로 예원이, 지수가 개발한 결과페이지 프론트엔드, 백엔드가 배포됩니다. 

로그인 시 email, password에 trim()을 추가했습니다.

## 🧪 테스트 방법
테스트 github Url : https://github.com/qkrwjdan/EBSStudySample
API 호출 시 해당 github 주소를 넣고 테스트합니다. 

시간이 지나면 해당 페이지가 노출됩니다. 
![스크린샷 2022-12-08 오후 5 23 09](https://user-images.githubusercontent.com/44994031/206395969-f4b1034b-2785-4bf2-821a-60194b295640.png)

## ✅ 궁금한 점 & 리뷰 포인트
@joohaem 
